### PR TITLE
DAOTHER-1891: For release date and other templated dates, spell out 3 October 2018

### DIFF
--- a/wwpdb/apps/msgmodule/io/DateUtil.py
+++ b/wwpdb/apps/msgmodule/io/DateUtil.py
@@ -1,0 +1,51 @@
+##
+#
+# File:    DateUtil.py
+# Author:  E. Peisach
+# Date:    17-Nov-2018
+# Version: 0.001
+# Updates:
+"""
+Class to manipulate dates for display purposes
+"""
+
+__docformat__ = "restructuredtext en"
+__author__ = "Ezra Peisach"
+__email__ = "ezra.peisach@rcsb.org"
+__license__ = "Creative Commons Attribution 3.0 Unported"
+__version__ = "V0.01"
+
+import datetime
+
+
+class DateUtil(object):
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def date_to_display(date):
+        """Converts incoming dateIn from ISO 8601 YYYY-MM-DD to Month number, year
+            If dateIn is '.' or '?' returns [UNKNOWN]. If date cannot be parsed, returns date.
+            This should be picked up by dictionary checks.
+        """
+
+        ret = '[UNKNOWN]'
+        if date not in ['.', '?']:
+            try:
+                dt = datetime.datetime.strptime(date, '%Y-%m-%d')
+                ret = dt.strftime('%-d %B %Y')
+            except ValueError:
+                ret = date
+
+        return ret
+
+
+def main():
+    du = DateUtil()
+    print(du.date_to_display('2018-10-08'))
+    print(du.date_to_display('2018-10'))
+    print(du.date_to_display('.'))
+
+
+if __name__ == '__main__':
+    main()

--- a/wwpdb/apps/tests-msgmodule/DateUtilTest.py
+++ b/wwpdb/apps/tests-msgmodule/DateUtilTest.py
@@ -1,0 +1,39 @@
+#
+# File: DateUtilTest.py
+# Date:  11-18-2018  E. Peisach
+#
+# Updates:
+##
+"""Test cases for DateUtil class"""
+
+__docformat__ = "restructuredtext en"
+__author__ = "Ezra Peisach"
+__email__ = "peisach@rcsb.rutgers.edu"
+__license__ = "Creative Commons Attribution 3.0 Unported"
+__version__ = "V0.01"
+
+import unittest
+
+from wwpdb.apps.msgmodule.io.DateUtil import DateUtil
+
+
+class DateUtilTests(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def _testsame(self, din, dexpect):
+        du = DateUtil()
+        self.assertEqual(du.date_to_display(din), dexpect)
+
+    def testDates(self):
+        """Tests date conversion"""
+        self._testsame('2018-10-01', '1 October 2018')
+        self._testsame('2018-10', '2018-10')
+        self._testsame('.', '[UNKNOWN]')
+        self._testsame('?', '[UNKNOWN]')
+        # 2018 is not a leap year - no conversion
+        self._testsame('2018-02-29', '2018-02-29')
+        self._testsame('2016-02-29', '29 February 2016')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The request was to spell out the release date in a more human form. Is 2018/01/02 YYYY/MM/DD or YYYY/DD/MM? ISO standard and PDB use YYYY/MM/DD - but some depositors have been confused.

While initial ticket requested was specifically about release date, I have updated for all templated messages in messaging.