### PR TITLE
DAOTHER-10545: Pass explicit site_id to PdbxMessageIo in MessagingIo

### DIFF
--- a/wwpdb/apps/msgmodule/db/DataAccessLayer.py
+++ b/wwpdb/apps/msgmodule/db/DataAccessLayer.py
@@ -81,14 +81,18 @@ def _get_or_create_engine(db_config: Dict):
                 echo=False  # Set to True for SQL debugging
             )
 
-            # Test connection and set max_allowed_packet for large messages
+            # Test connection
+            # NOTE: Disabled SET SESSION max_allowed_packet due to permission restrictions in production.
+            # Production database users typically lack SUPER privilege required for session-level settings.
+            # The application relies on the server's GLOBAL max_allowed_packet setting configured by the DBA.
+            # If large message inserts fail due to packet size, the DBA must increase GLOBAL max_allowed_packet.
             with engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
-                try:
-                    conn.execute(text("SET SESSION max_allowed_packet=67108864"))
-                    logger.info("Set SESSION max_allowed_packet to 64MB for large messages")
-                except Exception as e:
-                    logger.warning(f"Could not set max_allowed_packet (may require SUPER privilege): {e}")  # pylint: disable=logging-fstring-interpolation
+                # try:
+                #     conn.execute(text("SET SESSION max_allowed_packet=67108864"))
+                #     logger.info("Set SESSION max_allowed_packet to 64MB for large messages")
+                # except Exception as e:
+                #     logger.warning(f"Could not set max_allowed_packet (may require SUPER privilege): {e}")  # pylint: disable=logging-fstring-interpolation
 
                 logger.info("Database connection test successful")
 
@@ -236,18 +240,19 @@ class BaseDAO(Generic[ModelType]):
         Returns:
             bool: True if creation succeeded, False otherwise
 
-        Note:
-            Automatically sets SESSION max_allowed_packet to 64MB for large messages
         """
         max_retries = 3
         for attempt in range(max_retries):
             try:
                 with self.db_connection.get_session() as session:
-                    # Ensure max_allowed_packet is set for this session
-                    try:
-                        session.execute(text("SET SESSION max_allowed_packet=67108864"))
-                    except Exception:
-                        pass  # Ignore if we can't set it
+                    # NOTE: SET SESSION max_allowed_packet is disabled due to permission restrictions.
+                    # Production database users lack SUPER privilege. The application relies on the server's
+                    # GLOBAL max_allowed_packet setting. If inserts fail due to packet size, the DBA must
+                    # increase the global setting via: SET GLOBAL max_allowed_packet=...
+                    # try:
+                    #     session.execute(text("SET SESSION max_allowed_packet=67108864"))
+                    # except Exception:
+                    #     pass  # Ignore if we can't set it
 
                     session.add(obj)
                     session.commit()

--- a/wwpdb/apps/msgmodule/io/MessagingIo.py
+++ b/wwpdb/apps/msgmodule/io/MessagingIo.py
@@ -491,7 +491,7 @@ class MessagingIo(object):
 
                 # For database-backed storage (dummy paths), skip file existence checks
                 if self.__msgsFrmDpstrFilePath is not None and (self.__msgsFrmDpstrFilePath.startswith("/dummy") or os.access(self.__msgsFrmDpstrFilePath, os.R_OK)):
-                    pdbxMsgIo_frmDpstr = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+                    pdbxMsgIo_frmDpstr = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
                     try:
                         depId = str(self.__reqObj.getValue("identifier"))
                         ok = pdbxMsgIo_frmDpstr.read(self.__msgsFrmDpstrFilePath, deposition_id=depId)
@@ -504,7 +504,7 @@ class MessagingIo(object):
                             pdbxMsgIo_frmDpstr.close()  # Explicitly close to release database connections  # pylint: disable=no-member
 
                 if self.__msgsToDpstrFilePath is not None and (self.__msgsToDpstrFilePath.startswith("/dummy") or os.access(self.__msgsToDpstrFilePath, os.R_OK)):
-                    pdbxMsgIo_toDpstr = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+                    pdbxMsgIo_toDpstr = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
                     try:
                         depId = str(self.__reqObj.getValue("identifier"))
                         ok = pdbxMsgIo_toDpstr.read(self.__msgsToDpstrFilePath, deposition_id=depId)
@@ -521,7 +521,7 @@ class MessagingIo(object):
 
                 # For database-backed storage (dummy paths), skip file existence checks
                 if self.__notesFilePath is not None and (self.__notesFilePath.startswith("/dummy") or os.access(self.__notesFilePath, os.R_OK)):
-                    pdbxMsgIo_notes = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+                    pdbxMsgIo_notes = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
                     try:
                         depId = str(self.__reqObj.getValue("identifier"))
                         ok = pdbxMsgIo_notes.read(self.__notesFilePath, deposition_id=depId)
@@ -622,7 +622,7 @@ class MessagingIo(object):
 
                 # For database-backed storage (dummy paths), skip file existence checks
                 if self.__msgsFrmDpstrFilePath is not None and (self.__msgsFrmDpstrFilePath.startswith("/dummy") or os.access(self.__msgsFrmDpstrFilePath, os.R_OK)):
-                    pdbxMsgIo_frmDpstr = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+                    pdbxMsgIo_frmDpstr = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
                     depId = str(self.__reqObj.getValue("identifier"))
                     ok = pdbxMsgIo_frmDpstr.read(self.__msgsFrmDpstrFilePath, deposition_id=depId)
                     if ok:
@@ -634,7 +634,7 @@ class MessagingIo(object):
                             origCommsLst.extend(pdbxMsgIo_frmDpstr.getOrigCommReferenceInfo())
 
                 if self.__msgsToDpstrFilePath is not None and (self.__msgsToDpstrFilePath.startswith("/dummy") or os.access(self.__msgsToDpstrFilePath, os.R_OK)):
-                    pdbxMsgIo_toDpstr = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+                    pdbxMsgIo_toDpstr = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
                     depId = str(self.__reqObj.getValue("identifier"))
                     ok = pdbxMsgIo_toDpstr.read(self.__msgsToDpstrFilePath, deposition_id=depId)
                     if ok:
@@ -659,7 +659,7 @@ class MessagingIo(object):
 
                 # For database-backed storage (dummy paths), skip file existence checks
                 if self.__notesFilePath is not None and (self.__notesFilePath.startswith("/dummy") or os.access(self.__notesFilePath, os.R_OK)):
-                    pdbxMsgIo_notes = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+                    pdbxMsgIo_notes = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
                     depId = str(self.__reqObj.getValue("identifier"))
                     ok = pdbxMsgIo_notes.read(self.__notesFilePath, deposition_id=depId)
 
@@ -870,7 +870,7 @@ class MessagingIo(object):
 
             # For database-backed storage (dummy paths), skip file existence checks
             if self.__msgsFrmDpstrFilePath is not None and (self.__msgsFrmDpstrFilePath.startswith("/dummy") or os.access(self.__msgsFrmDpstrFilePath, os.R_OK)):
-                mIIo = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+                mIIo = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
                 with LockFile(
                     self.__msgsFrmDpstrFilePath, timeoutSeconds=self.__timeoutSeconds, retrySeconds=self.__retrySeconds, verbose=self.__verbose, log=self.__lfh
                 ) as _lf, FileSizeLogger(self.__msgsFrmDpstrFilePath, verbose=self.__verbose, log=self.__lfh) as _fsl:
@@ -882,7 +882,7 @@ class MessagingIo(object):
 
             # For database-backed storage (dummy paths), skip file existence checks
             if self.__msgsToDpstrFilePath is not None and (self.__msgsToDpstrFilePath.startswith("/dummy") or os.access(self.__msgsToDpstrFilePath, os.R_OK)):
-                mIIo2 = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+                mIIo2 = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
                 with LockFile(
                     self.__msgsToDpstrFilePath, timeoutSeconds=self.__timeoutSeconds, retrySeconds=self.__retrySeconds, verbose=self.__verbose, log=self.__lfh
                 ) as _lf, FileSizeLogger(  # noqa: F841
@@ -962,7 +962,7 @@ class MessagingIo(object):
 
             # For database-backed storage (dummy paths), skip file existence checks
             if self.__notesFilePath is not None and (self.__notesFilePath.startswith("/dummy") or os.access(self.__notesFilePath, os.R_OK)):
-                mIIo = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+                mIIo = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
                 with LockFile(
                     self.__notesFilePath, timeoutSeconds=self.__timeoutSeconds, retrySeconds=self.__retrySeconds, verbose=self.__verbose, log=self.__lfh
                 ) as _lf, FileSizeLogger(  # noqa: F841
@@ -1044,7 +1044,7 @@ class MessagingIo(object):
             else:
                 logger.info("Using database storage - skipping file operations for: %s", outputFilePth)
             #
-            mIIo = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+            mIIo = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
             with LockFile(outputFilePth, timeoutSeconds=self.__timeoutSeconds, retrySeconds=self.__retrySeconds, verbose=self.__verbose, log=self.__lfh) as _lf, FileSizeLogger(
                 outputFilePth, verbose=self.__verbose, log=self.__lfh
             ) as _fsl:  # noqa: F841
@@ -1654,7 +1654,7 @@ class MessagingIo(object):
         msgDI = MessagingDataImport(self.__reqObj, verbose=self.__verbose, log=self.__lfh)
         self.__msgsFrmDpstrFilePath = msgDI.getFilePath(contentType="messages-from-depositor", format="pdbx")
         logger.info("self.__msgsFromDpstrFilePath is: %s", self.__msgsFrmDpstrFilePath)
-        mIIo = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+        mIIo = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
         with LockFile(
             self.__msgsFrmDpstrFilePath, timeoutSeconds=self.__timeoutSeconds, retrySeconds=self.__retrySeconds, verbose=self.__verbose, log=self.__lfh
         ) as _lf, FileSizeLogger(  # noqa: F841
@@ -1726,7 +1726,7 @@ class MessagingIo(object):
                 except IOError:
                     pass
             #
-            mIIo = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+            mIIo = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
             with LockFile(
                 self.__msgsToDpstrFilePath, timeoutSeconds=self.__timeoutSeconds, retrySeconds=self.__retrySeconds, verbose=self.__verbose, log=self.__lfh
             ) as _lf, FileSizeLogger(
@@ -1850,7 +1850,7 @@ class MessagingIo(object):
 
             # For database-backed storage (dummy paths), skip file existence checks
             if self.__notesFilePath is not None and (self.__notesFilePath.startswith("/dummy") or os.access(self.__notesFilePath, os.R_OK)):
-                pdbxMsgIo_notes = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+                pdbxMsgIo_notes = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
                 depId = str(self.__reqObj.getValue("identifier"))
                 bGotContent = pdbxMsgIo_notes.read(self.__notesFilePath, deposition_id=depId)
 
@@ -1927,7 +1927,7 @@ class MessagingIo(object):
                 except IOError:
                     pass
             #
-            mIIo = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+            mIIo = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
             msgAlreadySeen = False
             with LockFile(
                 self.__msgsToDpstrFilePath, timeoutSeconds=self.__timeoutSeconds, retrySeconds=self.__retrySeconds, verbose=self.__verbose, log=self.__lfh
@@ -2002,8 +2002,8 @@ class MessagingIo(object):
         msgsFrmDpstrLst = []
         msgStatusLst = []
         fileSizeToDpstr = 0
-        mIIo = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
-        mIIo2 = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+        mIIo = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
+        mIIo2 = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
 
         try:
             # GET LIST OF IDS OF MSGS FROM DEPOSITOR
@@ -2152,7 +2152,7 @@ class MessagingIo(object):
             if self.__msgsToDpstrFilePath and (self.__msgsToDpstrFilePath.startswith("/dummy") or os.access(self.__msgsToDpstrFilePath, os.R_OK)):
                 fileSizeBytes = self.__getFileSizeBytes(self.__msgsToDpstrFilePath) if not self.__msgsToDpstrFilePath.startswith("/dummy") else 1
                 if fileSizeBytes > 0:
-                    mIIo = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+                    mIIo = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
                     with LockFile(
                         self.__msgsToDpstrFilePath, timeoutSeconds=self.__timeoutSeconds, retrySeconds=self.__retrySeconds, verbose=self.__verbose, log=self.__lfh
                     ) as _lf, FileSizeLogger(  # noqa: F841
@@ -2993,7 +2993,7 @@ class MessagingIo(object):
                 logger.info("self.__msgsToDpstrFilePath is: %s", self.__msgsToDpstrFilePath)
 
             if self.__msgsToDpstrFilePath is not None and os.access(self.__msgsToDpstrFilePath, os.R_OK):
-                mIIo = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
+                mIIo = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
                 with LockFile(
                     self.__msgsToDpstrFilePath, timeoutSeconds=self.__timeoutSeconds, retrySeconds=self.__retrySeconds, verbose=self.__verbose, log=self.__lfh
                 ) as _lf, FileSizeLogger(  # noqa: F841

--- a/wwpdb/apps/tests-msgmodule-db/MessagingIoTests.py
+++ b/wwpdb/apps/tests-msgmodule-db/MessagingIoTests.py
@@ -4,8 +4,21 @@ from io import StringIO
 import sys
 import os  # noqa: F401 pylint: disable=unused-import  # Need for mock changes
 
+# Allow local mock-only unit testing when MySQL client library is unavailable.
+try:
+    import MySQLdb  # noqa: F401  pylint: disable=unused-import
+except ImportError:
+    sys.modules['MySQLdb'] = Mock()
+
+try:
+    from wwpdb.utils.nmr.NmrDpUtility import NmrDpUtility  # noqa: F401  pylint: disable=unused-import
+except ImportError:
+    sys.modules['wwpdb.utils.nmr'] = Mock()
+    sys.modules['wwpdb.utils.nmr.NmrDpUtility'] = Mock(NmrDpUtility=Mock())
+
 # Import the class to test
 from wwpdb.apps.msgmodule.io.MessagingIo import MessagingIo
+from wwpdb.apps.msgmodule.io import CompatIo
 
 
 class TestMessagingIo(unittest.TestCase):
@@ -21,8 +34,14 @@ class TestMessagingIo(unittest.TestCase):
         self.session_obj.getRelativePath.return_value = 'relative_path'
         self.req_obj.newSessionObj.return_value = self.session_obj
 
-        # Initialize MessagingIo instance
-        self.messaging_io = MessagingIo(self.req_obj, verbose=False, log=StringIO())
+        # Initialize MessagingIo instance with config dependencies mocked so tests remain unit-level.
+        with patch('wwpdb.apps.msgmodule.io.MessagingIo.ConfigInfoAppMessaging') as mock_cfg_app, \
+             patch('wwpdb.apps.msgmodule.io.MessagingIo.ConfigInfo') as mock_cfg, \
+             patch('wwpdb.apps.msgmodule.io.MessagingIo.ConfigInfoAppEm') as mock_cfg_em:
+            mock_cfg_app.return_value.get_msgdb_support.return_value = True
+            mock_cfg.return_value.get.return_value = {}
+            mock_cfg_em.return_value.get_emd_mapping_file_path.return_value = '/tmp/emd_map_v2.cif'
+            self.messaging_io = MessagingIo(self.req_obj, verbose=False, log=StringIO())
 
     @patch('wwpdb.apps.msgmodule.io.MessagingIo.ConfigInfo')
     @patch('wwpdb.apps.msgmodule.io.MessagingIo.ConfigInfoAppEm')
@@ -94,6 +113,92 @@ class TestMessagingIo(unittest.TestCase):
         with patch.object(self.messaging_io, '_MessagingIo__isWorkflow', return_value=True):
             msg_dict = self.messaging_io.getMsg('test_id', 'D_000000')
         self.assertEqual(msg_dict['message_id'], 'test_id')
+
+    @patch('wwpdb.apps.msgmodule.io.MessagingIo.PdbxMessageIo')
+    @patch('wwpdb.apps.msgmodule.io.MessagingIo.MessagingDataImport')
+    @patch('os.access')
+    def test_getMsg_passes_site_id_to_pdbx_message_io(self, mock_access, mock_data_import, mock_pdbx_io):
+        """Verify MessagingIo always forwards explicit site_id into PdbxMessageIo."""
+        # Ensure request object returns stable values for all keys used in constructor and method.
+        value_map = {
+            'WWPDB_SITE_ID': 'WWPDB_DEPLOY_TEST',
+            'identifier': 'D_000000',
+            'content_type': 'msgs',
+            'groupid': '',
+        }
+        self.req_obj.getValue.side_effect = lambda key: value_map.get(key, 'test_value')
+
+        mock_access.return_value = True
+
+        mock_data_instance = Mock()
+        mock_data_import.return_value = mock_data_instance
+        mock_data_instance.getFilePath.return_value = '/tmp/message_file.cif'
+
+        mock_pdbx_instance = Mock()
+        mock_pdbx_io.return_value = mock_pdbx_instance
+        mock_pdbx_instance.read.return_value = True
+        mock_pdbx_instance.getMessageInfo.return_value = [
+            {
+                'message_id': 'test_id',
+                'message_text': 'test_text',
+                'timestamp': '2020-01-01 00:00:00',
+                'message_type': 'text',
+                'message_subject': 'Test Subject',
+                'sender': 'test_sender'
+            }
+        ]
+
+        # Re-initialize so __siteId picks up mapped WWPDB_SITE_ID.
+        with patch('wwpdb.apps.msgmodule.io.MessagingIo.ConfigInfoAppMessaging') as mock_cfg_app, \
+             patch('wwpdb.apps.msgmodule.io.MessagingIo.ConfigInfo') as mock_cfg, \
+             patch('wwpdb.apps.msgmodule.io.MessagingIo.ConfigInfoAppEm') as mock_cfg_em:
+            mock_cfg_app.return_value.get_msgdb_support.return_value = True
+            mock_cfg.return_value.get.return_value = {}
+            mock_cfg_em.return_value.get_emd_mapping_file_path.return_value = '/tmp/emd_map_v2.cif'
+            self.messaging_io = MessagingIo(self.req_obj, verbose=False, log=StringIO())
+
+        with patch.object(self.messaging_io, '_MessagingIo__isWorkflow', return_value=True):
+            self.messaging_io.getMsg('test_id', 'D_000000')
+
+        self.assertGreaterEqual(mock_pdbx_io.call_count, 1)
+        for _args, kwargs in mock_pdbx_io.call_args_list:
+            self.assertEqual(kwargs.get('site_id'), 'WWPDB_DEPLOY_TEST')
+
+
+class TestCompatIoRouting(unittest.TestCase):
+    """Focused unit tests for CompatIo routing logic using only mocks."""
+
+    @patch('wwpdb.apps.msgmodule.io.CompatIo.PdbxMessageIoLegacy')
+    @patch('wwpdb.apps.msgmodule.io.CompatIo.PdbxMessageIoDb')
+    @patch('wwpdb.apps.msgmodule.io.CompatIo.ConfigInfoAppMessaging')
+    @patch('wwpdb.apps.msgmodule.io.CompatIo.getSiteId')
+    def test_explicit_site_id_used_for_routing(self, mock_get_site, mock_cfg_app, mock_db_impl, mock_legacy_impl):
+        """Explicit site_id must be used and getSiteId() must not be consulted."""
+        mock_get_site.return_value = 'AUTO_SITE'
+        mock_cfg_app.return_value.get_msgdb_support.return_value = True
+
+        CompatIo.PdbxMessageIo(site_id='EXPLICIT_SITE', verbose=False)
+
+        mock_get_site.assert_not_called()
+        mock_cfg_app.assert_called_once_with('EXPLICIT_SITE')
+        mock_db_impl.assert_called_once()
+        mock_legacy_impl.assert_not_called()
+
+    @patch('wwpdb.apps.msgmodule.io.CompatIo.PdbxMessageIoLegacy')
+    @patch('wwpdb.apps.msgmodule.io.CompatIo.PdbxMessageIoDb')
+    @patch('wwpdb.apps.msgmodule.io.CompatIo.ConfigInfoAppMessaging')
+    @patch('wwpdb.apps.msgmodule.io.CompatIo.getSiteId')
+    def test_none_site_id_falls_back_to_getSiteId(self, mock_get_site, mock_cfg_app, mock_db_impl, mock_legacy_impl):
+        """When site_id is None, wrapper should resolve via getSiteId()."""
+        mock_get_site.return_value = 'AUTO_SITE'
+        mock_cfg_app.return_value.get_msgdb_support.return_value = False
+
+        CompatIo.PdbxMessageIo(site_id=None, verbose=False)
+
+        mock_get_site.assert_called_once_with()
+        mock_cfg_app.assert_called_once_with('AUTO_SITE')
+        mock_legacy_impl.assert_called_once()
+        mock_db_impl.assert_not_called()
 
     @patch('wwpdb.apps.msgmodule.io.MessagingIo.PdbxMessageIo')
     @patch('wwpdb.apps.msgmodule.io.MessagingIo.MessagingDataImport')


### PR DESCRIPTION
This PR fixes the database persistence path for messages sent through MessagingIo, particularly affecting EM validation letters (maponly-authstatus-em context type) that were reported as missing from the database.

## Background

After migrating from CIF file storage to the messaging database, we noticed that some messages weren't being persisted to the database even though they were successfully sent through the UI. The issue was intermittent and context-dependent.

## Root Cause

MessagingIo was creating PdbxMessageIo instances without passing an explicit site_id parameter:

```python
msgIo = PdbxMessageIo(verbose=self.__verbose, log=self.__lfh)
```

Without site_id, PdbxMessageIo falls back to calling getSiteId(), which can return None in certain request contexts. When site_id is None, the routing logic falls back to legacy CIF file storage instead of the database.

## Changes

Updated all 18 PdbxMessageIo instantiations in MessagingIo.py to pass the site_id explicitly:

```python
msgIo = PdbxMessageIo(site_id=self.__siteId, verbose=self.__verbose, log=self.__lfh)
```

This ensures consistent database routing regardless of request context. The changes cover all code paths including the live processMsg() write path, all query methods (getMessages, getMessage, etc.), and utility operations.

Also included:
- Unit tests verifying site_id propagation through MessagingIo
- Removed SESSION max_allowed_packet code (production users lack SUPER privilege, DBAs handle this globally)

## Validation

Tested end-to-end on PDBE_TEST environment. Sent an EM validation message through the production UI for D_800029 and confirmed it persists to the database:

```
Message ID: 7ef8a2e2-d290-4067-a6fd-7478b0268295
Context type: maponly-authstatus-em
Timestamp: 2026-03-06 14:52:03
```

The message is retrievable from the database, confirming the fix works for the reported issue.
